### PR TITLE
Twitter ratio

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ This fork includes a few extra features:
 
 * A *facebook* aspect ratio in *Quotable*, *Factlist* and *Waterbug*
 * Ability to highlight parts of text in *Quotable*
+* An updated *twitter* aspect ratio of 2x1 in *Quotable*, *Factlist* and *Waterbug*. The 16x9 aspect ratio is retained as well.
 
 Assumptions
 -------------

--- a/less/factlist.less
+++ b/less/factlist.less
@@ -307,7 +307,7 @@ canvas {
         }
     }
 
-    &.twitter-ratio {
+    &.two-by-one {
         height: 320px;
         padding: @padding;
 
@@ -457,7 +457,7 @@ canvas {
             height: @logo-16x9-height + @padding;
         }
 
-        .twitter-ratio& {
+        .two-by-one& {
             background-size: @logo-2x1-width @logo-2x1-height;
             width: @logo-2x1-width + @padding;
             height: @logo-2x1-height + @padding;

--- a/less/factlist.less
+++ b/less/factlist.less
@@ -307,6 +307,34 @@ canvas {
         }
     }
 
+    &.twitter-ratio {
+        height: 320px;
+        padding: @padding;
+
+        .quote& {
+            .left-quote {
+                top: @padding;
+                left: @padding;
+            }
+        }
+
+        blockquote {
+            margin-bottom: 20px;
+        }
+
+        .logo-wrapper {
+            padding: @padding;
+
+            img {
+                width: 150px;
+            }
+
+            .poster-music& {
+                padding-bottom: @padding - 10;
+            }
+        }
+    }
+
     &.facebook-ratio {
         width: 600px;
         height: 315px;
@@ -427,6 +455,12 @@ canvas {
             background-size: @logo-16x9-width @logo-16x9-height;
             width: @logo-16x9-width + @padding;
             height: @logo-16x9-height + @padding;
+        }
+
+        .twitter-ratio& {
+            background-size: @logo-2x1-width @logo-2x1-height;
+            width: @logo-2x1-width + @padding;
+            height: @logo-2x1-height + @padding;
         }
 
         .facebook-ratio& {

--- a/less/quotable.less
+++ b/less/quotable.less
@@ -301,6 +301,42 @@ canvas {
         }
     }
 
+    &.two-by-one {
+        height: 320px;
+        padding: @padding;
+
+        .quote& {
+            .left-quote {
+                top: @padding;
+                left: @padding;
+            }
+        }
+
+        blockquote {
+            margin-bottom: 20px;
+        }
+
+        .logo-wrapper {
+            padding: @padding;
+
+            img {
+                width: 150px;
+            }
+
+            .poster-music& {
+                padding-bottom: @padding - 10;
+            }
+        }
+
+        p.source {
+            font-size: @base-font-size * 1.3;
+        }
+
+        .show-credit {
+            font-size: @base-font-size * 1.1;
+        }
+    }
+
     .facebook-ratio& {
       width: 600px;
       height: 315px;
@@ -450,6 +486,12 @@ canvas {
             background-size: @logo-16x9-width @logo-16x9-height;
             width: @logo-16x9-width + @padding;
             height: @logo-16x9-height + @padding;
+        }
+
+        .two-by-one& {
+            background-size: @logo-2x1-width @logo-2x1-height;
+            width: @logo-2x1-width + @padding;
+            height: @logo-2x1-height + @padding;
         }
 
         .facebook-ratio& {

--- a/less/variables.less
+++ b/less/variables.less
@@ -11,6 +11,8 @@
 @logo-16x9-height: 80px;
 @logo-fb-ratio-width: 100px;
 @logo-fb-ratio-height: 80px;
+@logo-2x1-width: 100px;
+@logo-2x1-height: 80px;
 
 @padding: 30px;
 @base-font-size: 17px;

--- a/templates/factlist.html
+++ b/templates/factlist.html
@@ -46,7 +46,8 @@
                     <div class="form-group">
                         <label for="aspect-ratio">Aspect ratio</label>
                         <div id="aspect-ratio" class="btn-group">
-                            <button id="sixteen-by-nine" class="btn btn-primary active">16:9 <i class="fa fa-twitter"></i></button>
+                            <button id="sixteen-by-nine" class="btn btn-primary active">16:9</i></button>
+                            <button id="twitter-ratio" class="btn btn-primary">2:1 <i class="fa fa-twitter"></i></button>
                             <button id="facebook-ratio" class="btn btn-primary"><i class="fa fa-facebook"></i></button>
                             <button id="square" class="btn btn-primary">Square</button>
                         </div>

--- a/templates/factlist.html
+++ b/templates/factlist.html
@@ -47,7 +47,7 @@
                         <label for="aspect-ratio">Aspect ratio</label>
                         <div id="aspect-ratio" class="btn-group">
                             <button id="sixteen-by-nine" class="btn btn-primary active">16:9</i></button>
-                            <button id="twitter-ratio" class="btn btn-primary">2:1 <i class="fa fa-twitter"></i></button>
+                            <button id="two-by-one" class="btn btn-primary">2:1 <i class="fa fa-twitter"></i></button>
                             <button id="facebook-ratio" class="btn btn-primary"><i class="fa fa-facebook"></i></button>
                             <button id="square" class="btn btn-primary">Square</button>
                         </div>

--- a/templates/quotable.html
+++ b/templates/quotable.html
@@ -38,7 +38,8 @@
                     <div class="form-group">
                         <label for="aspect-ratio">Aspect ratio</label>
                         <div id="aspect-ratio" class="btn-group">
-                            <button id="sixteen-by-nine" class="btn btn-primary">16:9 <i class="fa fa-twitter"></i></button>
+                            <button id="sixteen-by-nine" class="btn btn-primary">16:9</i></button>
+                            <button id="two-by-one" class="btn btn-primary">2:1 <i class="fa fa-twitter"></i></button>
                             <button id="facebook-ratio" class="btn btn-primary"><i class="fa fa-facebook"></i></button>
                             <button id="square" class="btn btn-primary active">Square</button>
                         </div>

--- a/www/js/factlist.js
+++ b/www/js/factlist.js
@@ -172,9 +172,9 @@ var onThemeClick = function(e) {
 var onAspectRatioClick = function(e) {
     $aspectRatioButtons.removeClass().addClass('btn btn-primary');
     $(this).addClass('active');
-    $poster.removeClass('square sixteen-by-nine facebook-ratio').addClass($(this).attr('id'));
+    $poster.removeClass('square sixteen-by-nine facebook-ratio twitter-ratio').addClass($(this).attr('id'));
 
-    if ($poster.hasClass('sixteen-by-nine') || $poster.hasClass('facebook-ratio')) {
+    if ($poster.hasClass('sixteen-by-nine') || $poster.hasClass('facebook-ratio') || $poster.hasClass('twitter-ratio')) {
         $fontSize.attr('min', 24);
         $fontSize.val(24);
         adjustFontSize(null, 32);

--- a/www/js/factlist.js
+++ b/www/js/factlist.js
@@ -172,9 +172,9 @@ var onThemeClick = function(e) {
 var onAspectRatioClick = function(e) {
     $aspectRatioButtons.removeClass().addClass('btn btn-primary');
     $(this).addClass('active');
-    $poster.removeClass('square sixteen-by-nine facebook-ratio twitter-ratio').addClass($(this).attr('id'));
+    $poster.removeClass('square sixteen-by-nine facebook-ratio two-by-one').addClass($(this).attr('id'));
 
-    if ($poster.hasClass('sixteen-by-nine') || $poster.hasClass('facebook-ratio') || $poster.hasClass('twitter-ratio')) {
+    if ($poster.hasClass('sixteen-by-nine') || $poster.hasClass('facebook-ratio') || $poster.hasClass('two-by-one')) {
         $fontSize.attr('min', 24);
         $fontSize.val(24);
         adjustFontSize(null, 32);

--- a/www/js/quotable.js
+++ b/www/js/quotable.js
@@ -197,9 +197,9 @@ $(function() {
     $aspectRatioButtons.on('click', function() {
         $aspectRatioButtons.removeClass().addClass('btn btn-primary');
         $(this).addClass('active');
-        $poster.removeClass('square sixteen-by-nine facebook-ratio').addClass($(this).attr('id'));
+        $poster.removeClass('square sixteen-by-nine facebook-ratio two-by-one').addClass($(this).attr('id'));
 
-        if ($poster.hasClass('sixteen-by-nine') || $poster.hasClass('facebook-ratio')) {
+        if ($poster.hasClass('sixteen-by-nine') || $poster.hasClass('facebook-ratio') || $poster.hasClass('two-by-one')) {
             adjustFontSize(32);
             $fontSize.val(32);
         } else {


### PR DESCRIPTION
Adds a new twitter ratio to quotable and factlist. The twitter ratio was previously 16x9, which is no longer preferred for twitter images. Added a new ratio of 2x1 for twitter images.